### PR TITLE
Reenable renovate dashboard

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:base"],
 	"automergeType": "branch",
-	"dependencyDashboard": false,
+	"dependencyDashboard": true,
 	"packageRules": [
 		{
 			"updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
The dashboard is helpful for interacting with and seeing the current state of renovate. It's not noisy, just one standing issue that's edited/updated as renovate's state updates.