### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base"],
+	"extends": ["config:base", "config:js-lib"],
 	"automergeType": "branch",
 	"dependencyDashboard": false,
 	"packageRules": [
@@ -8,6 +8,15 @@
 			"updateTypes": ["minor", "patch", "pin", "digest"],
 			"automerge": true,
 		},
+		// Bunch up all non-major dependencies into a single PR.  In the common case
+    // where the upgrades apply cleanly, this causes less noise and is resolved faster
+    // than starting a bunch of upgrades in parallel for what may turn out to be
+    // a suite of related packages all released at once.
+    {
+      "groupName": "all non-major dependencies",
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupSlug": "all-minor-patch",
+    },
 		{
 			"matchPackageNames": ["@types/node"],
 			"allowedVersions": "14.x",

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,13 +1,9 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base", "config:js-lib"],
+	"extends": ["config:js-lib", ":widenPeerDependencies", ":automergeMinor"],
 	"automergeType": "branch",
 	"dependencyDashboard": false,
 	"packageRules": [
-		{
-			"updateTypes": ["minor", "patch", "pin", "digest"],
-			"automerge": true,
-		},
 		// Bunch up all non-major dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster
     // than starting a bunch of upgrades in parallel for what may turn out to be

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,14 +5,14 @@
 	"dependencyDashboard": false,
 	"packageRules": [
 		// Bunch up all non-major dependencies into a single PR.  In the common case
-    // where the upgrades apply cleanly, this causes less noise and is resolved faster
-    // than starting a bunch of upgrades in parallel for what may turn out to be
-    // a suite of related packages all released at once.
-    {
-      "groupName": "all non-major dependencies",
-      "matchUpdateTypes": ["patch", "minor"],
-      "groupSlug": "all-minor-patch",
-    },
+		// where the upgrades apply cleanly, this causes less noise and is resolved faster
+		// than starting a bunch of upgrades in parallel for what may turn out to be
+		// a suite of related packages all released at once.
+		{
+			"groupName": "all non-major dependencies",
+			"matchUpdateTypes": ["patch", "minor"],
+			"groupSlug": "all-minor-patch",
+		},
 		{
 			"matchPackageNames": ["@types/node"],
 			"allowedVersions": "14.x",


### PR DESCRIPTION
Use the [`js-lib` config](https://docs.renovatebot.com/presets-config/#configjs-lib), widen peers, simplify rules (use the preset for automerge).

Add a rule to combine all patch/minor updates into one PR. This will consolidate all the noisy patch updates into a single PR (right now this repo is blowing up my GH notifications)