### PR TITLE
Export and use custom JSON parser for GraphQL over http spec compliance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
 	"name": "@as-integrations/fastify",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@as-integrations/fastify",
-			"version": "1.1.1",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"fastify-plugin": "4.3.0"
 			},
 			"devDependencies": {
-				"@apollo/server": "4.2.0",
-				"@apollo/server-integration-testsuite": "4.2.0",
+				"@apollo/server": "4.2.2",
+				"@apollo/server-integration-testsuite": "4.2.2",
 				"@apollo/utils.withrequired": "1.0.1",
 				"@jest/types": "29.3.1",
 				"@oly_op/cspell-dict": "1.0.115",
@@ -152,18 +152,18 @@
 			"dev": true
 		},
 		"node_modules/@apollo/server": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.0.tgz",
-			"integrity": "sha512-iwJqD8wdgMW856nM4pf1Qcz5x8hHu2ZnMvIb/0cZhjE/0PN8ammPFtRYBTh5dZIAImWFrg9OsmFLBPDYMK5/rg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.2.tgz",
+			"integrity": "sha512-kcWnRy63KFrY1SxIVGX56wlMLRSgwmn2qR0IG0A7Mvrl6oXijVP5ETj7ulmwRcvvJsIoDOObhcCW5hW3UZy41Q==",
 			"dev": true,
 			"dependencies": {
 				"@apollo/cache-control-types": "^1.0.2",
-				"@apollo/server-gateway-interface": "^1.0.6",
+				"@apollo/server-gateway-interface": "^1.0.7",
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.createhash": "^2.0.0",
 				"@apollo/utils.fetcher": "^2.0.0",
 				"@apollo/utils.isnodelike": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@apollo/utils.logger": "^2.0.0",
 				"@apollo/utils.usagereporting": "^2.0.0",
 				"@apollo/utils.withrequired": "^2.0.0",
@@ -192,14 +192,14 @@
 			}
 		},
 		"node_modules/@apollo/server-gateway-interface": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.6.tgz",
-			"integrity": "sha512-7ebvJMBBzcppCHt0EpbfTjFbjUthpS/fkSiXMyi/kZ1ZkCmxW1jydG+iBmmSYtfYx9h9ZyI3kIBpzqHSHXR7IA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.7.tgz",
+			"integrity": "sha512-Eas36z851D0B0Hw8Ihpig2thHcoVAcFE7/I0+DAOaXr70r8kajPq5QHhngqFrlSTVl4AlJ7Yw1SGaWdvuSmDPQ==",
 			"dev": true,
 			"dependencies": {
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.fetcher": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@apollo/utils.logger": "^2.0.0"
 			},
 			"peerDependencies": {
@@ -207,22 +207,22 @@
 			}
 		},
 		"node_modules/@apollo/server-integration-testsuite": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.2.0.tgz",
-			"integrity": "sha512-Et73vsqh9x+DSOhxqlSeiK3dpxGvDK9fx/S8knHndzONUHsHB7api1nZvP3YLmbfMgPV645KnLY84TbsZSFQ/Q==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.2.2.tgz",
+			"integrity": "sha512-wi237GHEOQ5YYuDygef0iCAdnVCzyes1ebXr2eeG5PxiLhWl5nVLLktbO19S6y+tGfPHvSE0pUcylnsk/R+4pQ==",
 			"dev": true,
 			"dependencies": {
 				"@apollo/cache-control-types": "^1.0.2",
 				"@apollo/client": "^3.6.9",
-				"@apollo/server": "4.2.0",
+				"@apollo/server": "4.2.2",
 				"@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.createhash": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@josephg/resolvable": "^1.0.1",
 				"body-parser": "^1.20.0",
 				"express": "^4.18.1",
-				"graphql-http": "1.8.0",
+				"graphql-http": "1.9.0",
 				"graphql-tag": "^2.12.6",
 				"loglevel": "^1.8.0",
 				"node-fetch": "^2.6.7",
@@ -314,25 +314,16 @@
 			}
 		},
 		"node_modules/@apollo/utils.keyvaluecache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.0.tgz",
-			"integrity": "sha512-vf4gc2xr7IKU7EwCTzA5HDl1dxUNfvaJdauxXPNIXM96L9jhqEAyUFjJEQ7Ee85LGcjYCIWbr6yzmFRBYf1bbw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
+			"integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
 			"dev": true,
 			"dependencies": {
 				"@apollo/utils.logger": "^2.0.0",
-				"lru-cache": "^7.10.1 - 7.13.1"
+				"lru-cache": "^7.14.1"
 			},
 			"engines": {
 				"node": ">=14"
-			}
-		},
-		"node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
-			"version": "7.13.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-			"integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@apollo/utils.logger": {
@@ -6254,9 +6245,9 @@
 			}
 		},
 		"node_modules/graphql-http": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.8.0.tgz",
-			"integrity": "sha512-8nZJW5zybaKMa6pPXgZKW2Jy5pescyguhCwaF0eBLCmsErNbwT940ShHSZRTEseplAizXdea3CJEBsHUHYUlCw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+			"integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -7764,9 +7755,9 @@
 			}
 		},
 		"node_modules/lru-cache": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
-			"integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
 			"dev": true,
 			"engines": {
 				"node": ">=12"
@@ -10629,18 +10620,18 @@
 			}
 		},
 		"@apollo/server": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.0.tgz",
-			"integrity": "sha512-iwJqD8wdgMW856nM4pf1Qcz5x8hHu2ZnMvIb/0cZhjE/0PN8ammPFtRYBTh5dZIAImWFrg9OsmFLBPDYMK5/rg==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@apollo/server/-/server-4.2.2.tgz",
+			"integrity": "sha512-kcWnRy63KFrY1SxIVGX56wlMLRSgwmn2qR0IG0A7Mvrl6oXijVP5ETj7ulmwRcvvJsIoDOObhcCW5hW3UZy41Q==",
 			"dev": true,
 			"requires": {
 				"@apollo/cache-control-types": "^1.0.2",
-				"@apollo/server-gateway-interface": "^1.0.6",
+				"@apollo/server-gateway-interface": "^1.0.7",
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.createhash": "^2.0.0",
 				"@apollo/utils.fetcher": "^2.0.0",
 				"@apollo/utils.isnodelike": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@apollo/utils.logger": "^2.0.0",
 				"@apollo/utils.usagereporting": "^2.0.0",
 				"@apollo/utils.withrequired": "^2.0.0",
@@ -10671,34 +10662,34 @@
 			}
 		},
 		"@apollo/server-gateway-interface": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.6.tgz",
-			"integrity": "sha512-7ebvJMBBzcppCHt0EpbfTjFbjUthpS/fkSiXMyi/kZ1ZkCmxW1jydG+iBmmSYtfYx9h9ZyI3kIBpzqHSHXR7IA==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/@apollo/server-gateway-interface/-/server-gateway-interface-1.0.7.tgz",
+			"integrity": "sha512-Eas36z851D0B0Hw8Ihpig2thHcoVAcFE7/I0+DAOaXr70r8kajPq5QHhngqFrlSTVl4AlJ7Yw1SGaWdvuSmDPQ==",
 			"dev": true,
 			"requires": {
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.fetcher": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@apollo/utils.logger": "^2.0.0"
 			}
 		},
 		"@apollo/server-integration-testsuite": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.2.0.tgz",
-			"integrity": "sha512-Et73vsqh9x+DSOhxqlSeiK3dpxGvDK9fx/S8knHndzONUHsHB7api1nZvP3YLmbfMgPV645KnLY84TbsZSFQ/Q==",
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@apollo/server-integration-testsuite/-/server-integration-testsuite-4.2.2.tgz",
+			"integrity": "sha512-wi237GHEOQ5YYuDygef0iCAdnVCzyes1ebXr2eeG5PxiLhWl5nVLLktbO19S6y+tGfPHvSE0pUcylnsk/R+4pQ==",
 			"dev": true,
 			"requires": {
 				"@apollo/cache-control-types": "^1.0.2",
 				"@apollo/client": "^3.6.9",
-				"@apollo/server": "4.2.0",
+				"@apollo/server": "4.2.2",
 				"@apollo/server-plugin-landing-page-graphql-playground": "^4.0.0",
 				"@apollo/usage-reporting-protobuf": "^4.0.0",
 				"@apollo/utils.createhash": "^2.0.0",
-				"@apollo/utils.keyvaluecache": "^2.0.0",
+				"@apollo/utils.keyvaluecache": "^2.0.1",
 				"@josephg/resolvable": "^1.0.1",
 				"body-parser": "^1.20.0",
 				"express": "^4.18.1",
-				"graphql-http": "1.8.0",
+				"graphql-http": "1.9.0",
 				"graphql-tag": "^2.12.6",
 				"loglevel": "^1.8.0",
 				"node-fetch": "^2.6.7",
@@ -10753,21 +10744,13 @@
 			"dev": true
 		},
 		"@apollo/utils.keyvaluecache": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.0.tgz",
-			"integrity": "sha512-vf4gc2xr7IKU7EwCTzA5HDl1dxUNfvaJdauxXPNIXM96L9jhqEAyUFjJEQ7Ee85LGcjYCIWbr6yzmFRBYf1bbw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.0.1.tgz",
+			"integrity": "sha512-F1v3m2pMXPD3rb2+F79qklBBFtNSWssV+8YJIAI0iLxRxoNdDAzfrBFUseUaBaeen/e5mR54QkeNCiq8EvQ/Eg==",
 			"dev": true,
 			"requires": {
 				"@apollo/utils.logger": "^2.0.0",
-				"lru-cache": "^7.10.1 - 7.13.1"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "7.13.1",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.13.1.tgz",
-					"integrity": "sha512-CHqbAq7NFlW3RSnoWXLJBxCWaZVBrfa9UEHId2M3AW8iEBurbqduNexEUCGc3SHc6iCYXNJCDi903LajSVAEPQ==",
-					"dev": true
-				}
+				"lru-cache": "^7.14.1"
 			}
 		},
 		"@apollo/utils.logger": {
@@ -15356,9 +15339,9 @@
 			"dev": true
 		},
 		"graphql-http": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.8.0.tgz",
-			"integrity": "sha512-8nZJW5zybaKMa6pPXgZKW2Jy5pescyguhCwaF0eBLCmsErNbwT940ShHSZRTEseplAizXdea3CJEBsHUHYUlCw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/graphql-http/-/graphql-http-1.9.0.tgz",
+			"integrity": "sha512-MMwhHK24BRzf/AODYnT7eu3eCFHzoj1LBeB/8j+pFuhk539bnYQLP8Z/ey92PEgAbbL28lml7uZXbbCDYHVM1A==",
 			"dev": true,
 			"requires": {}
 		},
@@ -16483,9 +16466,9 @@
 			}
 		},
 		"lru-cache": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.0.tgz",
-			"integrity": "sha512-EIRtP1GrSJny0dqb50QXRUNBxHJhcpxHC++M5tD7RYbvLLn5KVWKsbyswSSqDuU15UFi3bgTQIY8nhDMeF6aDQ==",
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
+			"integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
 			"dev": true
 		},
 		"make-dir": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
 		"fastify": "^4.4.0"
 	},
 	"devDependencies": {
-		"@apollo/server": "4.2.0",
-		"@apollo/server-integration-testsuite": "4.2.0",
+		"@apollo/server": "4.2.2",
+		"@apollo/server-integration-testsuite": "4.2.2",
 		"@apollo/utils.withrequired": "1.0.1",
 		"@jest/types": "29.3.1",
 		"@oly_op/cspell-dict": "1.0.115",

--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,32 @@ interface ApolloFastifyPluginOptions<Context extends BaseContext = BaseContext>
 
 [`HTTPMethod`](https://www.fastify.io/docs/latest/Reference/TypeScript/#fastifyhttpmethods) is exported from Fastify.
 
+## GraphQL over HTTP spec compliance (optional)
+
+If you'd like your server to be compliant with the [GraphQL over HTTP spec](TODO), the JSON body parser must be overridden in order to allow spec-compliant handling of empty POST requests. The default Fastify JSON body parser will throw an error if the request body is empty, which is not compliant with the spec.
+
+If you are using the plugin, this is done automatically for you.
+
+If you are using the `fastifyHandler` function, you can disable the default JSON body parser and use ours like so:
+
+```typescript
+import Fastify from "fastify";
+import { ApolloServer, BaseContext } from "@apollo/server";
+import fastifyApollo, { getGraphQLHTTPJsonParser } from "@as-integrations/fastify";
+// ...
+
+const fastify = Fastify();
+
+fastify.removeContentTypeParser("application/json");
+fastify.addContentTypeParser(
+  "application/json",
+  { parseAs: "string" },
+  getGraphQLHTTPJsonParser(fastify),
+);
+
+// ...
+```
+
 ## **HTTPS/HTTP2**
 
 All functions and types optionally allow you to pass in or infer a `Server` type from Fastify.

--- a/src/graphql-http-json-parser.ts
+++ b/src/graphql-http-json-parser.ts
@@ -1,0 +1,23 @@
+import { FastifyInstance,FastifyReply,FastifyRequest } from "fastify";
+import { ContentTypeParserDoneFunction } from "fastify/types/content-type-parser";
+
+export function getGraphQLHTTPJsonParser<T extends FastifyInstance>(fastify: T) {
+	const defaultParser = fastify.getDefaultJsonParser("ignore", "ignore");
+	return function jsonParser(
+		request: FastifyRequest,
+		body: string,
+		done: ContentTypeParserDoneFunction,
+	) {
+		if (body === "" || body == null) {
+			const error = new Error("body is empty");
+			return done(null, { errors: [error], statusCode: 400 });
+		}
+
+		try {
+			return defaultParser(request, body, done);
+		} catch (error: unknown) {
+			(error as FastifyReply).statusCode = 400;
+			return done(error as Error);
+		}
+	};
+}

--- a/src/graphql-http-json-parser.ts
+++ b/src/graphql-http-json-parser.ts
@@ -1,4 +1,4 @@
-import { FastifyInstance,FastifyReply,FastifyRequest } from "fastify";
+import { FastifyInstance, FastifyReply, FastifyRequest } from "fastify";
 import { ContentTypeParserDoneFunction } from "fastify/types/content-type-parser";
 
 export function getGraphQLHTTPJsonParser<T extends FastifyInstance>(fastify: T) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./drain-plugin.js";
+export { getGraphQLHTTPJsonParser } from "./graphql-http-json-parser.js";
 export * from "./handler.js";
 export { fastifyApollo as default } from "./plugin.js";
 export * from "./types.js";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,14 +1,14 @@
 import type {
-FastifyPluginAsync,
-FastifyTypeProvider,
-FastifyTypeProviderDefault,
-RawServerBase,
-RawServerDefault,
+	FastifyPluginAsync,
+	FastifyTypeProvider,
+	FastifyTypeProviderDefault,
+	RawServerBase,
+	RawServerDefault,
 } from "fastify";
 
-import { ApolloServer,BaseContext } from "@apollo/server";
+import { ApolloServer, BaseContext } from "@apollo/server";
 import type { WithRequired } from "@apollo/utils.withrequired";
-import fp,{ PluginMetadata } from "fastify-plugin";
+import fp, { PluginMetadata } from "fastify-plugin";
 
 import { getGraphQLHTTPJsonParser } from "./graphql-http-json-parser.js";
 import { fastifyApolloHandler } from "./handler.js";

--- a/tests/handler.test.ts
+++ b/tests/handler.test.ts
@@ -9,6 +9,7 @@ import {
 	ApolloFastifyContextFunction,
 	fastifyApolloDrainPlugin,
 	fastifyApolloHandler,
+	getGraphQLHTTPJsonParser,
 } from "../src/index.js";
 import { FASTIFY_LISTEN_OPTIONS, METHODS } from "./options.js";
 
@@ -18,6 +19,16 @@ defineIntegrationTestSuite(
 		testOptions?: CreateServerForIntegrationTestsOptions,
 	) => {
 		const fastify = Fastify();
+
+		// Fastify has a default JSON parser that throws a specific error when the body is empty.
+		// A GraphQL server which is spec compliant (per the graphql-over-http spec) should respond
+		// with a JSON object with an `errors` key when the body is empty.
+		fastify.removeContentTypeParser(["application/json"]);
+		fastify.addContentTypeParser(
+			"application/json",
+			{ parseAs: "string" },
+			getGraphQLHTTPJsonParser(fastify),
+		);
 
 		const apollo = new ApolloServer({
 			...serverOptions,


### PR DESCRIPTION
Apollo Server adopted `graphql-http` spec compliance testing in the v4.2.0 release. Since taking this upgrade, this repo has been failing one of the spec-compliance tests.

In order to allow our users to run a spec-compliant GraphQL server, we should provide them with a spec-compliant JSON parser to override the default Fastify JSON parser. This merely means responding correctly to empty request bodies, with no other changes.