### PR TITLE
fix: unpin fastify-plugin dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"fastify-plugin": "4.4.0"
+				"fastify-plugin": "^4.4.0"
 			},
 			"devDependencies": {
 				"@apollo/server": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,6 @@
 		"typescript": "4.9.4"
 	},
 	"dependencies": {
-		"fastify-plugin": "4.4.0"
+		"fastify-plugin": "^4.4.0"
 	}
 }


### PR DESCRIPTION
Currently published version is 4.3.0. Adding a semver range will allow users to use a newer version without this module publishing a new version