### PR TITLE
Replace `instanceof` check with similar 'isApolloServerLike' check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
 				"jest": "29.3.1",
 				"jest-config": "29.3.1",
 				"jest-junit": "15.0.0",
-				"prettier": "2.8.3",
+				"prettier": "2.8.4",
 				"rimraf": "4.1.2",
 				"ts-jest": "29.0.5",
 				"ts-node": "10.9.1",
@@ -8735,9 +8735,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-			"integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+			"integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
@@ -17279,9 +17279,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-			"integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+			"version": "2.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+			"integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
 			"dev": true
 		},
 		"prettier-plugin-java": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
 		"jest": "29.3.1",
 		"jest-config": "29.3.1",
 		"jest-junit": "15.0.0",
-		"prettier": "2.8.3",
+		"prettier": "2.8.4",
 		"rimraf": "4.1.2",
 		"ts-jest": "29.0.5",
 		"ts-node": "10.9.1",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,12 @@
 import { ApolloServer, BaseContext } from "@apollo/server";
 import type { WithRequired } from "@apollo/utils.withrequired";
-import type { FastifyPluginAsync, FastifyTypeProvider, FastifyTypeProviderDefault, RawServerBase, RawServerDefault } from "fastify";
+import type {
+	FastifyPluginAsync,
+	FastifyTypeProvider,
+	FastifyTypeProviderDefault,
+	RawServerBase,
+	RawServerDefault,
+} from "fastify";
 import { PluginMetadata, fastifyPlugin } from "fastify-plugin";
 
 import { fastifyApolloHandler } from "./handler.js";
@@ -12,11 +18,7 @@ const pluginMetadata: PluginMetadata = {
 };
 
 function isApolloServerLike(maybeServer: unknown): maybeServer is ApolloServer {
-	return !!(
-		maybeServer &&
-		typeof maybeServer === "object" &&
-		"assertStarted" in maybeServer
-	); 
+	return !!(maybeServer && typeof maybeServer === "object" && "assertStarted" in maybeServer);
 }
 
 export function fastifyApollo<

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,12 +1,6 @@
 import { ApolloServer, BaseContext } from "@apollo/server";
 import type { WithRequired } from "@apollo/utils.withrequired";
-import type {
-	FastifyPluginAsync,
-	FastifyTypeProvider,
-	FastifyTypeProviderDefault,
-	RawServerBase,
-	RawServerDefault,
-} from "fastify";
+import type { FastifyPluginAsync, FastifyTypeProvider, FastifyTypeProviderDefault, RawServerBase, RawServerDefault } from "fastify";
 import { PluginMetadata, fastifyPlugin } from "fastify-plugin";
 
 import { fastifyApolloHandler } from "./handler.js";
@@ -16,6 +10,14 @@ const pluginMetadata: PluginMetadata = {
 	fastify: "^4.4.0",
 	name: "@as-integrations/fastify",
 };
+
+function isApolloServerLike(maybeServer: unknown): maybeServer is ApolloServer {
+	return !!(
+		maybeServer &&
+		typeof maybeServer === "object" &&
+		"assertStarted" in maybeServer
+	); 
+}
 
 export function fastifyApollo<
 	RawServer extends RawServerBase = RawServerDefault,
@@ -51,7 +53,7 @@ export function fastifyApollo<
 	RawServer,
 	TypeProvider
 > {
-	if (apollo === undefined || apollo === null || !(apollo instanceof ApolloServer<Context>)) {
+	if (apollo === undefined || apollo === null || !isApolloServerLike(apollo)) {
 		throw new TypeError("You must pass in an instance of `ApolloServer`.");
 	}
 


### PR DESCRIPTION
Fixes #126

`instanceof` tends to be problematic and isn't super necessary here anyway. Users who want to dynamically import from `@apollo/server` end up with failing `instanceof` checks. This replaces the `instanceof` check with a similar TS assertion function that looks for expected properties on the `ApolloServer` class.