### PR TITLE
fix: replace `instanceof` check everywhere

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,6 +16,7 @@ import type {
 
 import { fastifyRequestToGraphQLRequest } from "./fastify-request-to-graphql-request.js";
 import { ApolloFastifyContextFunction, ApolloFastifyHandlerOptions } from "./types.js";
+import { isApolloServerLike } from "./utils.js";
 
 interface RouteInterface extends RouteGenericInterface {
 	Reply: string;
@@ -87,7 +88,7 @@ export function fastifyApolloHandler<
 	TypeProvider,
 	Logger
 > {
-	if (apollo === undefined || apollo === null || !(apollo instanceof ApolloServer<Context>)) {
+	if (apollo === undefined || apollo === null || !isApolloServerLike(apollo)) {
 		throw new TypeError("You must pass in an instance of `ApolloServer`.");
 	}
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -11,15 +11,12 @@ import { PluginMetadata, fastifyPlugin } from "fastify-plugin";
 
 import { fastifyApolloHandler } from "./handler.js";
 import { ApolloFastifyPluginOptions } from "./types.js";
+import { isApolloServerLike } from "./utils.js";
 
 const pluginMetadata: PluginMetadata = {
 	fastify: "^4.4.0",
 	name: "@as-integrations/fastify",
 };
-
-function isApolloServerLike(maybeServer: unknown): maybeServer is ApolloServer {
-	return !!(maybeServer && typeof maybeServer === "object" && "assertStarted" in maybeServer);
-}
 
 export function fastifyApollo<
 	RawServer extends RawServerBase = RawServerDefault,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+import { ApolloServer } from "@apollo/server";
+
+export function isApolloServerLike(maybeServer: unknown): maybeServer is ApolloServer {
+	return !!(maybeServer && typeof maybeServer === "object" && "assertStarted" in maybeServer);
+};


### PR DESCRIPTION
Followup to #127, since the check was done twice.

If you prefer a different name for the `utils` file just LMK.