### PR TITLE
Drop support for Node v14 and add testing for Node v20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,6 @@ jobs:
       - run: npm run prettier-check
 
 workflows:
-  version: 2
   Build:
     jobs:
       - Lint
@@ -67,6 +66,6 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "14"
                 - "16"
                 - "18"
+                - "20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"@oly_op/tsconfig": "1.0.25",
 				"@swc/core": "1.3.57",
 				"@types/jest": "29.5.1",
-				"@types/node": "18.11.17",
+				"@types/node": "16.18.28",
 				"@types/rimraf": "3.0.2",
 				"@typescript-eslint/eslint-plugin": "5.59.5",
 				"cross-env": "7.0.3",
@@ -48,7 +48,7 @@
 				"typescript": "5.0.4"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=16"
 			},
 			"peerDependencies": {
 				"@apollo/server": "^4.0.0",
@@ -2941,9 +2941,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+			"version": "16.18.28",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+			"integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
 			"dev": true
 		},
 		"node_modules/@types/node-fetch": {
@@ -13108,9 +13108,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "18.11.17",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
+			"version": "16.18.28",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+			"integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
 			"dev": true
 		},
 		"@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"license": "MIT",
-	"version": "1.3.2",
 	"name": "@as-integrations/fastify",
+	"version": "1.3.2",
 	"description": "An Apollo Server integration for use with Fastify",
+	"license": "MIT",
 	"type": "module",
 	"main": "build/cjs/index.js",
 	"module": "build/esm/index.js",
@@ -18,7 +18,7 @@
 		"url": "https://github.com/apollo-server-integrations/apollo-server-integration-fastify.git"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=16"
 	},
 	"files": [
 		"build"
@@ -61,7 +61,7 @@
 		"@oly_op/tsconfig": "1.0.25",
 		"@swc/core": "1.3.57",
 		"@types/jest": "29.5.1",
-		"@types/node": "18.11.17",
+		"@types/node": "16.18.28",
 		"@types/rimraf": "3.0.2",
 		"@typescript-eslint/eslint-plugin": "5.59.5",
 		"cross-env": "7.0.3",

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ This is a simple package that easily allows you to connect your own Fastify serv
 
 ## **Requirements**
 
-- **[Node.js v14](https://nodejs.org/)** or later
+- **[Node.js v16](https://nodejs.org/)** or later
 - **[Fastify v4.4](https://www.fastify.io/)** or later
 - **[GraphQL.js v16](https://graphql.org/graphql-js/)** or later
 - **[Apollo Server v4](https://www.apollographql.com/docs/apollo-server/)** or later
@@ -182,7 +182,7 @@ interface ApolloFastifyPluginOptions<Context extends BaseContext = BaseContext>
 
 All functions and types optionally allow you to pass in or infer a `Server` type from Fastify.
 
-## **Node.JS v14**
+## **Node.JS v16**
 
 Please pass in `forceCloseConnections: true` to Fastify in combination with `fastifyApolloDrainPlugin` to correctly shutdown you're server on close and not hang incoming requests.
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,7 @@
 		},
 		{
 			"matchPackageNames": ["@types/node"],
-			"allowedVersions": "14.x",
+			"allowedVersions": "16.x",
 		},
 	],
 }

--- a/src/drain-plugin.ts
+++ b/src/drain-plugin.ts
@@ -32,7 +32,7 @@ export function fastifyApolloDrainPlugin<
 		async serverWillStart() {
 			return {
 				async drainServer() {
-					// `closeAllConnections` was added in v18.2 - @types/node are v14.
+					// `closeAllConnections` was added in v18.2 - @types/node are v16.
 					if ("closeAllConnections" in fastify.server) {
 						const timeout = setTimeout(() => {
 							// eslint-disable-next-line


### PR DESCRIPTION
Node v14 is EOL, we should drop support for it and release a new major version.

Fixes #182