### PR TITLE
Fix tsconfig, add build step to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - setup-node:
           node-version: <<parameters.node-version>>
+      - run: npm run build
       - run: npm run test:ci
       - store_test_results:
           path: junit.xml

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
 		"node": true,
 		"jest": true
 	},
+	"ignorePatterns": ["build", "node_modules"],
 	"parserOptions": {
 		"project": "./tsconfig.json"
 	},

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"target": "ES2021",
 		"module": "CommonJS",
+		"moduleResolution": "Node",
 		"outDir": "./build/cjs"
 	},
 	"include": ["src"]

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,7 +1,6 @@
 {
 	"extends": ".",
 	"compilerOptions": {
-		"module": "ESNext",
 		"outDir": "./build/esm"
 	},
 	"include": ["src"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
 	"extends": "@oly_op/tsconfig/tsconfig",
 	"compilerOptions": {
 		"lib": ["ES2021"],
-		"declaration": true
+		"declaration": true,
+		"module": "NodeNext"
 	},
 	"ts-node": {
 		"esm": true,


### PR DESCRIPTION
Without a build step in CI, we took a TypeScript update that actually causes `npm run build` to fail. Our tsconfig needed to be updated for cjs and esm.

This fixes the respective tsconfigs and adds a build step to CI to make sure that doesn't break in the future.