### PR TITLE
Remove redundant types

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 	],
 	"exports": {
 		".": {
-			"types": "./build/esm/index.d.ts",
 			"import": "./build/esm/index.js",
 			"require": "./build/cjs/index.js"
 		}


### PR DESCRIPTION
### Changed
- Updated `package.json` without redundant types.

### Previous analysis
Before applying any changes and checking https://arethetypeswrong.github.io/, the results were as follows:

<main style="box-sizing: border-box; flex: 1 1 0%; color: rgb(255, 255, 255); font-family: system-ui, -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div id="package-info" class="" style="box-sizing: border-box; padding: 0px 1rem;"><h2 style="box-sizing: border-box;">@as-integrations/fastify v2.1.0<span> </span><small style="box-sizing: border-box;">(<a href="https://npmjs.com/@as-integrations/fastify" style="box-sizing: border-box; color: var(--color-link);">npm</a>,<span> </span><a href="https://unpkg.com/browse/@as-integrations/fastify@2.1.0/" style="box-sizing: border-box; color: var(--color-link);">unpkg</a>)</small></h2><h3 style="box-sizing: border-box;">Build tools</h3><ul style="box-sizing: border-box;"><li style="box-sizing: border-box;"><code style="box-sizing: border-box;">typescript@5.2.2</code></li></ul></div><p id="problems" style="box-sizing: border-box; padding: 0px 1rem; max-width: 800px; position: sticky; left: 0px; width: 100vw;"><h3 style="box-sizing: border-box;">Problems</h3><dl style="box-sizing: border-box;"><dt style="box-sizing: border-box; float: left; padding: 0.5em 0px;">👺</dt><dd style="box-sizing: border-box; margin-inline-start: 30px; padding: 0.5em 0px;"><p style="box-sizing: border-box; max-width: 800px; margin: 0px;"><strong style="box-sizing: border-box;"><a href="https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseESM.md" style="box-sizing: border-box; color: var(--color-link);">Masquerading as ESM</a></strong></p><p style="box-sizing: border-box; max-width: 800px; margin: 0px;">Import resolved to an ESM type declaration file, but a CommonJS JavaScript file.</p></dd><dt style="box-sizing: border-box; float: left; padding: 0.5em 0px;">⚠️</dt><dd style="box-sizing: border-box; margin-inline-start: 30px; padding: 0.5em 0px;"><p style="box-sizing: border-box; max-width: 800px; margin: 0px;"><strong style="box-sizing: border-box;"><a href="https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/CJSResolvesToESM.md" style="box-sizing: border-box; color: var(--color-link);">ESM (dynamic import only)</a></strong></p><p style="box-sizing: border-box; max-width: 800px; margin: 0px;">A<span> </span><code style="box-sizing: border-box;">require</code><span> </span>call resolved to an ESM JavaScript file, which is an error in Node and some bundlers. CommonJS consumers will need to use a dynamic import.</p></dd><dt style="box-sizing: border-box; float: left; padding: 0.5em 0px;">🤨</dt><dd style="box-sizing: border-box; margin-inline-start: 30px; padding: 0.5em 0px;"><p style="box-sizing: border-box; max-width: 800px; margin: 0px;"><strong style="box-sizing: border-box;"><a href="https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/CJSOnlyExportsDefault.md" style="box-sizing: border-box; color: var(--color-link);">CJS default export</a></strong></p><p style="box-sizing: border-box; max-width: 800px; margin: 0px;">CommonJS module simulates a default export with<span> </span><code style="box-sizing: border-box;">exports.default</code><span> </span>and<span> </span><code style="box-sizing: border-box;">exports.__esModule</code>, but does not also set<span> </span><code style="box-sizing: border-box;">module.exports</code><span> </span>for compatibility with Node. Node, and<span> </span><a href="https://andrewbranch.github.io/interop-test/#synthesizing-default-exports-for-cjs-modules" style="box-sizing: border-box; color: var(--color-link);">some bundlers under certain conditions</a>, do not respect the<span> </span><code style="box-sizing: border-box;">__esModule</code><span> </span>marker, so accessing the intended default export will require a<span> </span><code style="box-sizing: border-box;">.default</code><span> </span>property access on the default import.</p></dd></dl></p><div style="box-sizing: border-box; padding: 0px 1rem;">

  | "@as-integrations/fastify"
-- | --
node10 | 🤨 CJS default export
node16 (from CJS) | 👺 Masquerading as ESM⚠️ ESM (dynamic import only)🤨 CJS default export
node16 (from ESM) | ✅ (ESM)
bundler | ✅


### Current analysis
After applying the PR changes and checking https://arethetypeswrong.github.io/, the results are as follows:

<main style="box-sizing: border-box; flex: 1 1 0%; color: rgb(255, 255, 255); font-family: system-ui, -apple-system, BlinkMacSystemFont, Roboto, Oxygen, Ubuntu, Cantarell, &quot;Open Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div id="package-info" class="" style="box-sizing: border-box; padding: 0px 1rem;"><h2 style="box-sizing: border-box;">@as-integrations/fastify v2.1.0<span> </span><small style="box-sizing: border-box;">(<a href="https://npmjs.com/@as-integrations/fastify" style="box-sizing: border-box; color: var(--color-link);">npm</a>,<span> </span><a href="https://unpkg.com/browse/@as-integrations/fastify@2.1.0/" style="box-sizing: border-box; color: var(--color-link);">unpkg</a>)</small></h2><h3 style="box-sizing: border-box;">Build tools</h3><ul style="box-sizing: border-box;"><li style="box-sizing: border-box;"><code style="box-sizing: border-box;">typescript@5.2.2</code></li></ul></div><p id="problems" style="box-sizing: border-box; padding: 0px 1rem; max-width: 800px; position: sticky; left: 0px; width: 100vw;"><h3 style="box-sizing: border-box;">Problems</h3><dl style="box-sizing: border-box;"><dt style="box-sizing: border-box; float: left; padding: 0.5em 0px;">🤨</dt><dd style="box-sizing: border-box; margin-inline-start: 30px; padding: 0.5em 0px;"><p style="box-sizing: border-box; max-width: 800px; margin: 0px;"><strong style="box-sizing: border-box;"><a href="https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/CJSOnlyExportsDefault.md" style="box-sizing: border-box; color: var(--color-link);">CJS default export</a></strong></p><p style="box-sizing: border-box; max-width: 800px; margin: 0px;">CommonJS module simulates a default export with<span> </span><code style="box-sizing: border-box;">exports.default</code><span> </span>and<span> </span><code style="box-sizing: border-box;">exports.__esModule</code>, but does not also set<span> </span><code style="box-sizing: border-box;">module.exports</code><span> </span>for compatibility with Node. Node, and<span> </span><a href="https://andrewbranch.github.io/interop-test/#synthesizing-default-exports-for-cjs-modules" style="box-sizing: border-box; color: var(--color-link);">some bundlers under certain conditions</a>, do not respect the<span> </span><code style="box-sizing: border-box;">__esModule</code><span> </span>marker, so accessing the intended default export will require a<span> </span><code style="box-sizing: border-box;">.default</code><span> </span>property access on the default import.</p></dd></dl></p><div style="box-sizing: border-box; padding: 0px 1rem;">

  | "@as-integrations/fastify"
-- | --
node10 | 🤨 CJS default export
node16 (from CJS) | 🤨 CJS default export
node16 (from ESM) | ✅ (ESM)
bundler | ✅
